### PR TITLE
Fix Copilot SDK AgentSkill startup compatibility

### DIFF
--- a/app/agui_server.py
+++ b/app/agui_server.py
@@ -48,7 +48,7 @@ def create_app() -> FastAPI:
         # Copilot SDK can load and apply them across all sessions.
         load_skills()
 
-        client = CopilotClient(github_token=github_token) if github_token else CopilotClient()
+        client = CopilotClient()
         await client.start()
         set_client(client)
         logger.info("CopilotClient started (GitHub Copilot SDK)")

--- a/app/src/jobs.py
+++ b/app/src/jobs.py
@@ -17,7 +17,7 @@ from copilot.session import PermissionHandler
 
 from src.config import settings
 from src.models import JobStatusResponse
-from src.skills import get_disabled_skills, get_skill_directories, should_enable_skills
+from src.skills import get_disabled_skills, get_skill_directories
 from src.state import get_client
 
 _jobs: dict[str, JobStatusResponse] = {}
@@ -46,7 +46,6 @@ async def _call_session(prompt: str, system_message: str | None) -> str:
         system_message={"mode": "replace", "content": sys_content},
         streaming=True,
         available_tools=[],
-        enable_skills=should_enable_skills(),
         skill_directories=get_skill_directories(),
         disabled_skills=get_disabled_skills(),
     )

--- a/app/src/orchestrator.py
+++ b/app/src/orchestrator.py
@@ -23,7 +23,7 @@ from copilot.session import PermissionHandler
 from src.config import settings
 from src.logging_utils import setup_logging
 from src.patterns import AgentRole, get_pattern
-from src.skills import get_disabled_skills, get_skill_directories, should_enable_skills
+from src.skills import get_disabled_skills, get_skill_directories
 from src.state import get_client
 
 logger = setup_logging(settings.log_level)
@@ -69,7 +69,6 @@ async def _collect_agent(role: AgentRole, prompt: str, context: str) -> tuple[st
         system_message={"mode": "replace", "content": sys_content},
         streaming=True,
         available_tools=[],
-        enable_skills=should_enable_skills(),
         skill_directories=get_skill_directories(),
         disabled_skills=get_disabled_skills(),
     )
@@ -113,7 +112,6 @@ async def _stream_agent(
         system_message={"mode": "replace", "content": sys_content},
         streaming=True,
         available_tools=[],
-        enable_skills=should_enable_skills(),
         skill_directories=get_skill_directories(),
         disabled_skills=get_disabled_skills(),
     )

--- a/app/src/skills.py
+++ b/app/src/skills.py
@@ -109,17 +109,6 @@ def get_skill_directories() -> list[str]:
     return list(_skill_directories)
 
 
-def should_enable_skills() -> bool | None:
-    """Return the SDK skill toggle for sessions.
-
-    Passing only ``skill_directories`` lets the Copilot SDK discover paths, but
-    it does not turn on Agent Skills. The SDK also requires
-    ``enable_skills=True`` to activate them; leaving it unset preserves SDK
-    defaults when no skills are configured.
-    """
-    return True if _skill_directories else None
-
-
 def get_disabled_skills() -> list[str]:
     """Return skill names the operator has opted to disable."""
     raw = settings.disabled_skills

--- a/app/src/state.py
+++ b/app/src/state.py
@@ -7,7 +7,7 @@ import time
 from copilot import CopilotClient
 from copilot.session import CopilotSession, PermissionHandler
 
-from src.skills import get_disabled_skills, get_skill_directories, should_enable_skills
+from src.skills import get_disabled_skills, get_skill_directories
 
 _client: CopilotClient | None = None
 
@@ -55,7 +55,6 @@ class SessionPool:
 
             client = get_client()
             github_token = os.environ.get("GITHUB_TOKEN")
-            enable_skills = should_enable_skills()
             skill_directories = get_skill_directories()
             disabled_skills = get_disabled_skills()
             try:
@@ -65,7 +64,6 @@ class SessionPool:
                     system_message={"mode": "replace", "content": _SYSTEM_MESSAGE},
                     streaming=True,
                     available_tools=[],
-                    enable_skills=enable_skills,
                     skill_directories=skill_directories,
                     disabled_skills=disabled_skills,
                     github_token=github_token,
@@ -78,7 +76,6 @@ class SessionPool:
                     system_message={"mode": "replace", "content": _SYSTEM_MESSAGE},
                     streaming=True,
                     available_tools=[],
-                    enable_skills=enable_skills,
                     skill_directories=skill_directories,
                     disabled_skills=disabled_skills,
                     github_token=github_token,

--- a/app/tests/test_agui_server.py
+++ b/app/tests/test_agui_server.py
@@ -14,10 +14,11 @@ from fastapi.testclient import TestClient
 @pytest.fixture
 def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     """Create app with mocked CopilotClient so no real auth is needed."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     mock_client = MagicMock()
     mock_client.start = AsyncMock()
     mock_client.stop = AsyncMock()
-    monkeypatch.setattr("agui_server.CopilotClient", lambda *_args, **_kwargs: mock_client)
+    monkeypatch.setattr("agui_server.CopilotClient", lambda: mock_client)
     from agui_server import create_app
 
     return create_app()
@@ -46,6 +47,23 @@ def test_health_check_endpoint(client: TestClient) -> None:
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "healthy"}
+
+
+def test_lifespan_starts_client_with_github_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Startup must not pass GITHUB_TOKEN to the CopilotClient constructor."""
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    mock_client = MagicMock()
+    mock_client.start = AsyncMock()
+    mock_client.stop = AsyncMock()
+    copilot_client = MagicMock(return_value=mock_client)
+    monkeypatch.setattr("agui_server.CopilotClient", copilot_client)
+    from agui_server import create_app
+
+    with TestClient(create_app()) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    copilot_client.assert_called_once_with()
 
 
 def test_security_headers(client: TestClient) -> None:

--- a/app/tests/test_session_pool_skills.py
+++ b/app/tests/test_session_pool_skills.py
@@ -42,7 +42,7 @@ def isolate_skills_and_client(monkeypatch: pytest.MonkeyPatch) -> Generator[None
 async def test_session_pool_enables_sdk_skills_when_directories_loaded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The Copilot SDK must receive enable_skills=True with skill directories."""
+    """The Copilot SDK must receive skill directories using supported kwargs."""
     client = _FakeClient()
     monkeypatch.delenv("COPILOT_API_SKILL_DIRECTORIES", raising=False)
     skill_directories = load_skills()
@@ -53,7 +53,7 @@ async def test_session_pool_enables_sdk_skills_when_directories_loaded(
         await pool.get_or_create("thread-with-skills")
 
         assert client.create_kwargs is not None
-        assert client.create_kwargs["enable_skills"] is True
+        assert "enable_skills" not in client.create_kwargs
         assert client.create_kwargs["skill_directories"] == skill_directories
     finally:
         await pool.shutdown()

--- a/app/tests/test_skills.py
+++ b/app/tests/test_skills.py
@@ -17,7 +17,6 @@ from src.skills import (
     get_loaded_skill_names,
     get_skill_directories,
     load_skills,
-    should_enable_skills,
 )
 
 REPO_SKILLS = (Path(__file__).resolve().parent.parent / "skills").resolve()
@@ -57,7 +56,6 @@ def test_load_skills_discovers_repo_directory() -> None:
         assert "secure-coding-advisor" in names
         # get_skill_directories returns the cached list
         assert get_skill_directories() == dirs
-        assert should_enable_skills() is True
     finally:
         _reset_cache()
 
@@ -109,4 +107,3 @@ def test_get_skill_directories_empty_before_load() -> None:
     _reset_cache()
     assert get_skill_directories() == []
     assert get_loaded_skill_names() == []
-    assert should_enable_skills() is None


### PR DESCRIPTION
The AG-UI server was failing during startup because the current locked GitHub Copilot SDK does not accept `github_token` on `CopilotClient`. Cross-checking `github-copilot-sdk==1.0.0b3` also showed that session creation supports `skill_directories` and `disabled_skills`, but not the previously added `enable_skills` flag.

This change keeps AgentSkill discovery intact while aligning all Copilot SDK calls with the supported API surface: the shared client is constructed without token kwargs, and session creation/resume paths pass only supported skill and token options. Regression coverage now asserts startup works with `GITHUB_TOKEN` set and that skill configuration avoids unsupported kwargs.

Validation:
- `git diff --check`
- `python -m py_compile app\agui_server.py app\src\state.py app\src\jobs.py app\src\orchestrator.py app\src\skills.py app\tests\test_agui_server.py app\tests\test_session_pool_skills.py app\tests\test_skills.py`

Note: full pytest/lint validation could not run in this environment because `uv run pytest` stalled during dependency preparation and global `pytest`/`ruff`/`mypy` were unavailable.

Fixes: #162