### PR TITLE
refactor(app): deduplicate skill and tool parsing

### DIFF
--- a/app/src/parsing.py
+++ b/app/src/parsing.py
@@ -1,0 +1,8 @@
+"""Small parsing helpers shared across app modules."""
+
+
+def split_comma_separated(value: str | None) -> list[str]:
+    """Return trimmed, non-empty comma-separated values."""
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]

--- a/app/src/skills.py
+++ b/app/src/skills.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from src.config import settings
 from src.logging_utils import setup_logging
+from src.parsing import split_comma_separated
 
 logger = setup_logging(settings.log_level)
 
@@ -43,23 +44,24 @@ def _extra_directories_from_env() -> list[Path]:
 
 def _has_any_skill(directory: Path) -> bool:
     """Return True if *directory* contains at least one ``<name>/SKILL.md``."""
+    return any(_iter_skill_folders(directory))
+
+
+def _iter_skill_folders(directory: Path) -> Iterable[Path]:
+    """Yield ``<name>/SKILL.md`` folders under *directory*."""
     if not directory.is_dir():
-        return False
+        return
     for entry in directory.iterdir():
         if entry.is_dir() and (entry / "SKILL.md").is_file():
-            return True
-    return False
+            yield entry
 
 
 def _enumerate_skill_names(directories: Iterable[Path]) -> list[str]:
     """Return sorted unique skill folder names found under *directories*."""
     names: set[str] = set()
     for d in directories:
-        if not d.is_dir():
-            continue
-        for entry in d.iterdir():
-            if entry.is_dir() and (entry / "SKILL.md").is_file():
-                names.add(entry.name)
+        for entry in _iter_skill_folders(d):
+            names.add(entry.name)
     return sorted(names)
 
 
@@ -111,10 +113,7 @@ def get_skill_directories() -> list[str]:
 
 def get_disabled_skills() -> list[str]:
     """Return skill names the operator has opted to disable."""
-    raw = settings.disabled_skills
-    if not raw:
-        return []
-    return [s.strip() for s in raw.split(",") if s.strip()]
+    return split_comma_separated(settings.disabled_skills)
 
 
 def get_loaded_skill_names() -> list[str]:

--- a/app/src/state.py
+++ b/app/src/state.py
@@ -13,6 +13,7 @@ from copilot.session import CopilotSession, PermissionHandler
 
 from src.config import settings
 from src.logging_utils import setup_logging
+from src.parsing import split_comma_separated
 from src.skills import get_disabled_skills, get_skill_directories
 
 logger = setup_logging(settings.log_level)
@@ -29,7 +30,7 @@ def _get_allowed_tools() -> list[str] | None:
     if value is None:
         return None
 
-    non_empty_tools = [tool.strip() for tool in value.split(",") if tool.strip()]
+    non_empty_tools = split_comma_separated(value)
     return non_empty_tools or None
 
 


### PR DESCRIPTION
## Summary
- Refactored `app/src/skills.py` to remove duplicated SKILL.md folder scanning logic via `_iter_skill_folders`.
- Added shared parser utility `app/src/parsing.py` and reused it for comma-separated settings parsing.
- Simplified `get_disabled_skills` and `_get_allowed_tools` to use the shared parser.

## Testing
- `uv run ruff check .`
- `uv run pytest tests/test_skills.py tests/test_session_pool_skills.py -v`