### PR TITLE
fix: diagnose GitHub App OAuth 403 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ Configure the GitHub App **Callback URL** (not the Webhook URL) to match
 `COPILOT_APP_REDIRECT_URI`; the production value is
 `https://app-agentic-devops.azurewebsites.net/auth/callback`.
 
+For a GitHub App, use the App's **Client ID** (not the numeric App ID), enable
+user authorization/OAuth in the App settings, and add the callback under the
+App's user authorization settings. The application starts the standard OAuth
+flow at `https://github.com/login/oauth/authorize`; a 403 before the callback
+usually indicates that the App credentials, user authorization setting, or
+callback URL do not match.
+
 ### 3. Start the backend
 
 ```bash

--- a/app/README.md
+++ b/app/README.md
@@ -48,6 +48,13 @@ Configure the GitHub App **Callback URL** (not the Webhook URL) to match
 `COPILOT_APP_REDIRECT_URI`; the production value is
 `https://app-agentic-devops.azurewebsites.net/auth/callback`.
 
+Use the App's **Client ID** (not the numeric App ID), enable user
+authorization/OAuth in the App settings, and add the callback under the App's
+user authorization settings. The login route uses GitHub's standard
+`https://github.com/login/oauth/authorize` endpoint; a 403 before the callback
+usually means the App credentials, user authorization setting, or callback URL
+do not match.
+
 ### 3. Start the backend
 
 ```bash

--- a/app/tests/test_agui_server.py
+++ b/app/tests/test_agui_server.py
@@ -87,6 +87,7 @@ def test_github_oauth_login_redirects_with_csrf_state(monkeypatch: pytest.Monkey
         response = test_client.get("/auth/login", follow_redirects=False)
 
     assert response.status_code == 307
+    assert urlparse(response.headers["location"]).path == "/login/oauth/authorize"
     query = parse_qs(urlparse(response.headers["location"]).query)
     assert query["client_id"] == ["client-id"]
     assert query["redirect_uri"] == [agui_server.settings.github_oauth_redirect_uri]


### PR DESCRIPTION
## Summary\n\n- Keep the GitHub App OAuth flow on the documented /login/oauth/authorize endpoint.\n- Add regression coverage asserting the production authorization path and query parameters.\n- Document the GitHub App settings required for production: Client ID (not App ID), user authorization/OAuth enabled, and Callback URL (not Webhook URL).\n\n## Diagnosis\n\nThe deployed service currently returns the expected 307 redirect to the documented endpoint with the configured callback and CSRF state. GitHub's documented OAuth flow and the Copilot SDK guide both use this endpoint for GitHub Apps. Changing it to /login would be an unsupported workaround and would not fix the underlying configuration. A 403 after the redirect therefore points to the remote GitHub App/user authorization settings or callback registration, which cannot be verified from repository access alone.\n\nCloses #215